### PR TITLE
Fix PHP Fatal error:  Class 'Codeception\Module\Module' not found

### DIFF
--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -2,6 +2,7 @@
 
 namespace Codeception\Module;
 
+use Codeception\Module;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Stream;
 


### PR DESCRIPTION
Resolves #22 