### PR TITLE
Add Codeception Module use statement back.

### DIFF
--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -2,6 +2,7 @@
 
 namespace Codeception\Module;
 
+use Codeception\Module;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\Assert;


### PR DESCRIPTION
Resolves #33 

This seems to be getting lost on merges, it was already implemented as part of https://github.com/WhatDaFox/Codeception-Mailtrap/pull/23/