### PR TITLE
Handle API deprecation of html and text body message properties

### DIFF
--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -121,9 +121,9 @@ class Mailtrap extends Module
 
         $messages = json_decode($messages, true);
 
-        foreach ($messages as $key => $message) {
-            $messages[$key] = new MailtrapMessage($messages);
-        }
+	    foreach ( $messages as $key => $message ) {
+		    $messages[ $key ] = new MailtrapMessage( $message, $this->client );
+	    }
 
         return $messages;
     }

--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -125,6 +125,26 @@ class Mailtrap extends Module
     }
 
     /**
+     * Get the most recent messages of the default inbox.
+     *
+     * @param int $number
+     *
+     * @return array
+     */
+    public function fetchLastMessages($number = 1)
+    {
+        $messages = $this->fetchMessages();
+
+        $firstIndex = count($messages) - $number;
+
+        $messages = array_slice($messages, $firstIndex, $number);
+
+        $this->assertCount($number, $messages);
+
+        return $messages;
+    }
+
+    /**
      * Get the most recent message of the default inbox.
      *
      * @return array
@@ -299,26 +319,6 @@ class Mailtrap extends Module
     {
         $attachments = $this->fetchAttachmentsOfLastMessage();
         $this->assertEquals($bool, count($attachments) > 0);
-    }
-
-    /**
-     * Get the most recent messages of the default inbox.
-     *
-     * @param int $number
-     *
-     * @return array
-     */
-    public function fetchLastMessages($number = 1)
-    {
-        $messages = $this->fetchMessages();
-
-        $firstIndex = count($messages) - $number;
-
-        $messages = array_slice($messages, $firstIndex, $number);
-
-        $this->assertCount($number, $messages);
-
-        return $messages;
     }
 
     /**

--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -102,7 +102,7 @@ class Mailtrap extends Module
         $message = $this->fetchLastMessage();
 
         foreach ($params as $param => $value) {
-            $this->assertEquals($value, $message[$param]);
+            $this->assertEquals($value, $message->{$param});
         }
     }
 
@@ -120,6 +120,10 @@ class Mailtrap extends Module
         }
 
         $messages = json_decode($messages, true);
+
+        foreach ($messages as $key => $message) {
+            $messages[$key] = new MailtrapMessage($messages);
+        }
 
         return $messages;
     }
@@ -147,7 +151,7 @@ class Mailtrap extends Module
     /**
      * Get the most recent message of the default inbox.
      *
-     * @return array
+     * @return MailtrapMessage
      */
     public function fetchLastMessage()
     {
@@ -164,7 +168,7 @@ class Mailtrap extends Module
     public function fetchAttachmentsOfLastMessage()
     {
         $email = $this->fetchLastMessage();
-        $response = $this->client->get("inboxes/{$this->config['inbox_id']}/messages/{$email['id']}/attachments")->getBody();
+        $response = $this->client->get("inboxes/{$this->config['inbox_id']}/messages/{$email->id}/attachments")->getBody();
 
         return json_decode($response, true);
     }
@@ -179,7 +183,7 @@ class Mailtrap extends Module
     public function receiveAnEmailFromEmail($senderEmail)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($senderEmail, $message['from_email']);
+        $this->assertEquals($senderEmail, $message->from_email);
     }
 
     /**
@@ -192,7 +196,7 @@ class Mailtrap extends Module
     public function receiveAnEmailFromName($senderName)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($senderName, $message['from_name']);
+        $this->assertEquals($senderName, $message->from_name);
     }
 
     /**
@@ -205,7 +209,7 @@ class Mailtrap extends Module
     public function receiveAnEmailToEmail($recipientEmail)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($recipientEmail, $message['to_email']);
+        $this->assertEquals($recipientEmail, $message->to_email);
     }
 
     /**
@@ -218,7 +222,7 @@ class Mailtrap extends Module
     public function receiveAnEmailToName($recipientName)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($recipientName, $message['to_name']);
+        $this->assertEquals($recipientName, $message->to_name);
     }
 
     /**
@@ -231,7 +235,7 @@ class Mailtrap extends Module
     public function receiveAnEmailWithSubject($subject)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($subject, $message['subject']);
+        $this->assertEquals($subject, $message->subject);
     }
 
     /**
@@ -244,7 +248,7 @@ class Mailtrap extends Module
     public function receiveAnEmailWithTextBody($textBody)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($textBody, $message['text_body']);
+        $this->assertEquals($textBody, $message->text_body);
     }
 
     /**
@@ -257,7 +261,7 @@ class Mailtrap extends Module
     public function receiveAnEmailWithHtmlBody($htmlBody)
     {
         $message = $this->fetchLastMessage();
-        $this->assertEquals($htmlBody, $message['html_body']);
+        $this->assertEquals($htmlBody, $message->html_body);
     }
 
     /**
@@ -270,7 +274,7 @@ class Mailtrap extends Module
     public function seeInEmailTextBody($expected)
     {
         $email = $this->fetchLastMessage();
-        $this->assertContains($expected, $email['text_body'], 'Email body contains text');
+        $this->assertContains($expected, $email->text_body, 'Email body contains text');
     }
 
     /**
@@ -283,7 +287,7 @@ class Mailtrap extends Module
     public function seeInEmailHtmlBody($expected)
     {
         $email = $this->fetchLastMessage();
-        $this->assertContains($expected, $email['html_body'], 'Email body contains HTML');
+        $this->assertContains($expected, $email->html_body, 'Email body contains HTML');
     }
 
 	/**
@@ -296,7 +300,7 @@ class Mailtrap extends Module
 	public function seeInEmailSubject($expected)
 	{
 		$email = $this->fetchLastMessage();
-		$this->assertContains($expected, $email['subject'], 'Email subject contains text');
+		$this->assertContains($expected, $email->subject, 'Email subject contains text');
 	}
 
     /**
@@ -387,7 +391,7 @@ class Mailtrap extends Module
             $emails = $this->fetchMessages();
             foreach ($emails as $email) {
                 $constraint = Assert::equalTo($subject);
-                if ($constraint->evaluate($email['subject'], '', true)) {
+                if ($constraint->evaluate($email->subject, '', true)) {
                     return true;
                 }
             }
@@ -414,7 +418,7 @@ class Mailtrap extends Module
             $emails = $this->fetchMessages();
             foreach ($emails as $email) {
                 $constraint = Assert::stringContains($text);
-                if ($constraint->evaluate($email['text_body'], '', true)) {
+                if ($constraint->evaluate($email->text_body, '', true)) {
                     return true;
                 }
             }
@@ -441,7 +445,7 @@ class Mailtrap extends Module
             $emails = $this->fetchMessages();
             foreach ($emails as $email) {
                 $constraint = Assert::stringContains($text);
-                if ($constraint->evaluate($email['html_body'], '', true)) {
+                if ($constraint->evaluate($email->html_body, '', true)) {
                     return true;
                 }
             }

--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -2,6 +2,7 @@
 
 namespace Codeception\Module;
 
+use Codeception\Module;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Stream;
 use PHPUnit\Framework\Assert;

--- a/src/Mailtrap.php
+++ b/src/Mailtrap.php
@@ -310,13 +310,7 @@ class Mailtrap extends Module
      */
     public function fetchLastMessages($number = 1)
     {
-        $messages = $this->client->get("inboxes/{$this->config['inbox_id']}/messages")->getBody();
-
-        if ($messages instanceof Stream) {
-            $messages = $messages->getContents();
-        }
-
-        $messages = json_decode($messages, true);
+        $messages = $this->fetchMessages();
 
         $firstIndex = count($messages) - $number;
 

--- a/src/MailtrapMessage.php
+++ b/src/MailtrapMessage.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Codeception\Module;
+
+/**
+ * Represents a message in the MailTrap inbox
+ *
+ */
+class MailtrapMessage
+{
+
+    /**
+     * @var array Message payload
+     */
+    protected $data;
+
+    /**
+     * MailtrapMessage constructor.
+     *
+     * @param array $data
+     */
+    public function __construct($data = [])
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed|null
+     */
+    public function __get($name)
+    {
+        if (isset($this->data[$name])) {
+            return $this->data[$name];
+        }
+
+        return null;
+    }
+}

--- a/src/MailtrapMessage.php
+++ b/src/MailtrapMessage.php
@@ -2,39 +2,102 @@
 
 namespace Codeception\Module;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\Stream;
+
 /**
  * Represents a message in the MailTrap inbox
  *
  */
-class MailtrapMessage
-{
+class MailtrapMessage {
 
-    /**
-     * @var array Message payload
-     */
-    protected $data;
+	/**
+	 * @var array Message payload
+	 */
+	protected $data;
 
-    /**
-     * MailtrapMessage constructor.
-     *
-     * @param array $data
-     */
-    public function __construct($data = [])
-    {
-        $this->data = $data;
-    }
+	/**
+	 * @var Client
+	 */
+	protected $client;
 
-    /**
-     * @param string $name
-     *
-     * @return mixed|null
-     */
-    public function __get($name)
-    {
-        if (isset($this->data[$name])) {
-            return $this->data[$name];
-        }
+	/**
+	 * @var string HTML body of the message
+	 */
+	protected $html_body;
 
-        return null;
-    }
+	/**
+	 * @var string Text body of the message
+	 */
+	protected $text_body;
+
+	/**
+	 * MailtrapMessage constructor.
+	 *
+	 * @param array  $data
+	 * @param Client $client
+	 */
+	public function __construct( $data = [], Client $client ) {
+		$this->data   = $data;
+		$this->client = $client;
+	}
+
+	/**
+	 * @param string $name
+	 *
+	 * @return mixed|null
+	 */
+	public function __get( $name ) {
+		if ( in_array( $name, array( 'html_body', 'text_body' ) ) ) {
+			return $this->getMessageData( $name );
+		}
+
+		if ( isset( $this->data[ $name ] ) ) {
+			return $this->data[ $name ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the body data for a message
+	 *
+	 * @param $key
+	 *
+	 * @return bool|mixed|null|string
+	 */
+	public function getMessageData( $key ) {
+		if ( $this->{$key} ) {
+			return $this->{$key};
+		}
+
+		$data_key = str_replace( 'body', 'path', $key );
+
+		$data = $this->retrieveMessageData( $data_key );
+
+		if ( ! $data ) {
+			return '';
+		}
+
+		$this->{$key} = $data;
+
+		return $data;
+	}
+
+	/**
+	 * Retrieve the body data from the MailTrap API
+	 *
+	 * @param $key
+	 *
+	 * @return bool|string
+	 */
+	protected function retrieveMessageData( $key ) {
+		$data = $this->client->get( $this->data[ $key ] )->getBody();
+
+		if ( $data instanceof Stream ) {
+			return $data->getContents();
+		}
+
+		return false;
+	}
 }


### PR DESCRIPTION
Resolves #34 

Has https://github.com/WhatDaFox/Codeception-Mailtrap/pull/35 cherry picked in so it could work.